### PR TITLE
Fix permission for uploading release assets; add release assets to NuGet publishing

### DIFF
--- a/.github/workflows/publish-app.yml
+++ b/.github/workflows/publish-app.yml
@@ -235,6 +235,8 @@ jobs:
     needs: [build_dotnet]
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Download .NET artifact
         uses: actions/download-artifact@v4
@@ -269,6 +271,8 @@ jobs:
     needs: [build_spa]
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Download SPA artifact
         uses: actions/download-artifact@v4
@@ -303,6 +307,8 @@ jobs:
     needs: [build_spa]
     if: github.event_name == 'release' && inputs.analysis_artifacts
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Download SPA analysis artifact
         uses: actions/download-artifact@v4
@@ -337,6 +343,8 @@ jobs:
     needs: [build_spa]
     if: github.event_name == 'release' && inputs.persisted_documents_file
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Download SPA persisted-documents artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -136,3 +136,40 @@ jobs:
         run: |
           echo "Publishing to: ${{ steps.nuget_config.outputs.target }}"
           dotnet nuget push "packages/*.nupkg" -k ${{ steps.nuget_config.outputs.auth_token }} --skip-duplicate
+
+  release_assets:
+    name: Publish .NET Release Assets
+    needs: build
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download .NET artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: '.net-app'
+          path: packages
+      - name: Zip files together
+        working-directory: packages
+        run: zip -r ../nuget-packages.zip .
+      - name: Upload nuget-packages.zip as Release Asset
+        uses: actions/github-script@v7
+        continue-on-error: true
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const fileData = fs.readFileSync(path.join(process.cwd(), 'nuget-packages.zip'));
+            const uploadResult = await github.rest.repos.uploadReleaseAsset({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: context.payload.release.id,
+              name: 'nuget-packages.zip',
+              data: fileData,
+              headers: {
+                'content-type': 'application/zip',
+                'content-length': fileData.length,
+              },
+            });
+  

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -172,4 +172,3 @@ jobs:
                 'content-length': fileData.length,
               },
             });
-  

--- a/publish-app.md
+++ b/publish-app.md
@@ -120,7 +120,7 @@ jobs:
   publish-application:
     uses: Shane32/SharedWorkflows/.github/workflows/publish-app.yml@v2
     permissions:
-      contents: read
+      contents: write
       id-token: write
     with:
       dotnet_folder: '.'
@@ -150,7 +150,7 @@ jobs:
   publish-application:
     uses: Shane32/SharedWorkflows/.github/workflows/publish-app.yml@v2
     permissions:
-      contents: read
+      contents: write
       id-token: write
     with:
       spa_folder: ReactApp
@@ -179,7 +179,7 @@ jobs:
   publish-application:
     uses: Shane32/SharedWorkflows/.github/workflows/publish-app.yml@v2
     permissions:
-      contents: read
+      contents: write
       id-token: write
     with:
       dotnet_folder: '.'
@@ -199,3 +199,4 @@ The above example assumes that the necessary Azure configuration values are stor
 - `NUGET_ORG_USER` and `NUGET_ORG_TOKEN` should already be configured as organization secrets but need to be passed in.
 - `global.json` is required
 - Cannot override .NET SDK with another version or install multiple SDKs
+- `permissions: contents: write` is necessary to upload the compiled application as a release asset

--- a/publish-nuget.md
+++ b/publish-nuget.md
@@ -104,6 +104,8 @@ on:
 jobs:
   publish:
     uses: Shane32/SharedWorkflows/.github/workflows/publish-nuget.yml@v2
+    permissions:
+      contents: write
     with:
       dotnet_folder: '.'
     secrets:
@@ -129,6 +131,8 @@ on:
 jobs:
   publish:
     uses: Shane32/SharedWorkflows/.github/workflows/publish-nuget.yml@v2
+    permissions:
+      contents: write
     with:
       dotnet_folder: '.'
     secrets:
@@ -237,3 +241,4 @@ For individual library projects that should be packaged, set `IsPackable` to `tr
 - The workflow runs on Ubuntu latest
 - Authentication is automatically configured based on the target repository
 - For GitHub Packages, the repository owner is automatically extracted from the GitHub context
+- `permissions: contents: write` is necessary to upload nuget packages as release assets


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated uploading of build artifacts as release assets during release events.

* **Documentation**
  * Updated workflow documentation to clarify and demonstrate the required permissions for uploading release assets.
  * Added notes explaining the need for write permissions when publishing release assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->